### PR TITLE
:bug: Failed to judge when str is an empty string and when both source and str are a charcter.

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -31,6 +31,7 @@ Deno.test("check `test()`", () => {
 
 const testData: Record<string, [string, number][]> = {
   "": [
+    ["", 0],
     ["a", 1],
     ["ab", 2],
     ["abc", 3],
@@ -39,6 +40,7 @@ const testData: Record<string, [string, number][]> = {
   ],
   "a": [
     ["a", 0],
+    ["", 1],
     ["b", 1],
     ["ab", 1],
     ["bab", 2],
@@ -51,6 +53,7 @@ const testData: Record<string, [string, number][]> = {
     ["a", 1],
     ["aa", 1],
     ["abc", 1],
+    ["", 2],
     ["bac", 2],
     ["bcd", 3],
     ["bcde", 4],
@@ -63,6 +66,7 @@ const testData: Record<string, [string, number][]> = {
     ["a", 2],
     ["acb", 2],
     ["aabcd", 2],
+    ["", 3],
     ["bca", 3],
   ],
   "abcde": [
@@ -75,12 +79,14 @@ const testData: Record<string, [string, number][]> = {
     ["abXXde", 2],
     ["ae", 3],
     ["aedcb", 4],
+    ["", 4],
   ],
   "ab de": [
     ["abcde", 0],
     ["abccde", 0],
     ["abXXXXXXXde", 0],
     ["abcccccxe", 1],
+    ["", 4],
   ],
   "漢字文字列": [
     ["漢字文字列", 0],
@@ -89,6 +95,7 @@ const testData: Record<string, [string, number][]> = {
     ["漢字文字烈", 1],
     ["漢字辞典", 3],
     ["漢和辞典", 4],
+    ["", 4],
   ],
   "emoji✅": [
     ["emoji✅", 0],
@@ -97,6 +104,7 @@ const testData: Record<string, [string, number][]> = {
     ["emoji⬜", 1],
     ["emmoji⬜", 2],
     ["emoji⬜✅❌", 2],
+    ["", 4],
   ],
 };
 Deno.test("check `match()`", async (t) => {

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -30,6 +30,41 @@ Deno.test("check `test()`", () => {
 });
 
 const testData: Record<string, [string, number][]> = {
+  "": [
+    ["a", 1],
+    ["ab", 2],
+    ["abc", 3],
+    ["abcd", 4],
+    ["abcde", 5],
+  ],
+  "a": [
+    ["a", 0],
+    ["b", 1],
+    ["ab", 1],
+    ["bab", 2],
+    ["abcd", 3],
+    ["bcde", 4],
+    ["abcde", 4],
+  ],
+  "ab": [
+    ["ab", 0],
+    ["a", 1],
+    ["aa", 1],
+    ["abc", 1],
+    ["bac", 2],
+    ["bcd", 3],
+    ["bcde", 4],
+  ],
+  "abc": [
+    ["abc", 0],
+    ["ac", 1],
+    ["abb", 1],
+    ["aabc", 1],
+    ["a", 2],
+    ["acb", 2],
+    ["aabcd", 2],
+    ["bca", 3],
+  ],
   "abcde": [
     ["abcde", 0],
     ["aBCDe", 0],
@@ -54,6 +89,14 @@ const testData: Record<string, [string, number][]> = {
     ["漢字文字烈", 1],
     ["漢字辞典", 3],
     ["漢和辞典", 4],
+  ],
+  "emoji✅": [
+    ["emoji✅", 0],
+    ["emoj✅", 1],
+    ["emojji✅", 1],
+    ["emoji⬜", 1],
+    ["emmoji⬜", 2],
+    ["emoji⬜✅❌", 2],
   ],
 };
 Deno.test("check `match()`", async (t) => {

--- a/mod.ts
+++ b/mod.ts
@@ -89,6 +89,7 @@ export function Asearch(source: string): AsearchResult {
   const [shiftMasks, epsilonMask, acceptState] = preparePatterns(source);
 
   function test(str: string, maxDistance: 0 | 1 | 2 | 3 = 0) {
+    if (str === "") return maxDistance >= source.length;
     const state = moveState(str, shiftMasks, epsilonMask);
     return (state[maxDistance] & acceptState) !== 0;
   }
@@ -96,6 +97,11 @@ export function Asearch(source: string): AsearchResult {
   function match(
     str: string,
   ): MatchResult {
+    if (str === "") {
+      return 3 < source.length
+        ? { found: false }
+        : { found: true, distance: source.length as 0 | 1 | 2 | 3 };
+    }
     const state = moveState(
       str,
       shiftMasks,

--- a/mod.ts
+++ b/mod.ts
@@ -96,24 +96,22 @@ export function Asearch(source: string): AsearchResult {
   function match(
     str: string,
   ): MatchResult {
-    const [state0, state1, state2, state3] = moveState(
+    const state = moveState(
       str,
       shiftMasks,
       epsilonMask,
     );
-    if ((state3 & acceptState) === 0) {
-      return { found: false };
+    let flag = false;
+    for (let i = INITSTATE.length - 1; i >= 0; i--) {
+      if ((state[i] & acceptState) === 0) {
+        if (flag) {
+          return { found: true, distance: i + 1 as 0 | 1 | 2 | 3 };
+        }
+      } else {
+        flag = true;
+      }
     }
-    return {
-      found: true,
-      distance: (state0 & acceptState) !== 0
-        ? 0
-        : (state1 & acceptState) !== 0
-        ? 1
-        : (state2 & acceptState) !== 0
-        ? 2
-        : 3,
-    };
+    return flag ? { found: true, distance: 0 } : { found: false };
   }
 
   return {


### PR DESCRIPTION
close [⬜1文字長の文字列をdeno-asearchで比較できない](https://scrapbox.io/takker/⬜1文字長の文字列をdeno-asearchで比較できない)