### PR TITLE
:sparkles: Enable to use case sensitive search

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -9,24 +9,34 @@ Deno.test('shoud have property "source"', () => {
   assertEquals(asearch.source, "abcde");
 });
 
-Deno.test("check `test()`", () => {
-  const { test } = Asearch("abcde");
-  assert(test("abcde", 0));
-  assert(test("abcde", 1));
-  assert(test("abcde", 2));
-  assert(test("abcde", 3));
-  assert(!test("abccde", 0));
-  assert(test("abccde", 1));
-  assert(test("abccde", 2));
-  assert(test("abccde", 3));
-  assert(!test("abde", 0));
-  assert(test("abde", 1));
-  assert(test("abde", 2));
-  assert(test("abde", 3));
-  assert(!test("abdde", 0));
-  assert(test("abdde", 1));
-  assert(test("abdde", 2));
-  assert(test("abdde", 3));
+Deno.test("check `test()`", async (t) => {
+  await t.step("ignoreCase: true", () => {
+    const { test } = Asearch("abcde");
+    assert(test("abcde", 0));
+    assert(test("aBCDe", 0));
+    assert(test("abcde", 1));
+    assert(test("abcde", 2));
+    assert(test("abcde", 3));
+    assert(!test("abccde", 0));
+    assert(test("abccde", 1));
+    assert(test("abccde", 2));
+    assert(test("abccde", 3));
+    assert(!test("abde", 0));
+    assert(test("abde", 1));
+    assert(test("abde", 2));
+    assert(test("abde", 3));
+    assert(!test("abdde", 0));
+    assert(test("abdde", 1));
+    assert(test("abdde", 2));
+    assert(test("abdde", 3));
+  });
+
+  await t.step("ignoreCase: false", () => {
+    const { test } = Asearch("abcde", { ignoreCase: false });
+    assert(test("abcde", 0));
+    assert(!test("aBCDe", 0));
+    assert(test("aBCDe", 3));
+  });
 });
 
 const testData: Record<string, [string, number][]> = {

--- a/mod.ts
+++ b/mod.ts
@@ -12,11 +12,20 @@ export interface Mask {
   accept: number;
 }
 
+/** options for search */
+export interface SearchOption {
+  /** turn false if you want to disable case insensitive search
+   *
+   * @default true
+   */
+  ignoreCase?: boolean;
+}
 /** あいまい検索に使うマスクを作成する
  *
  * @param source 検索対象の文字列
  */
-export function makeMask(source: string): Mask {
+export function makeMask(source: string, option?: SearchOption): Mask {
+  const { ignoreCase = true } = option ?? {};
   const shift = new Map<string, number>();
   let wild = 0;
   let accept = INITPATTERN;
@@ -24,7 +33,11 @@ export function makeMask(source: string): Mask {
     if (char === wildCard) {
       wild |= accept;
     } else {
-      for (const i of [char, char.toLowerCase(), char.toUpperCase()]) {
+      for (
+        const i of ignoreCase
+          ? [char, char.toLowerCase(), char.toUpperCase()]
+          : [char]
+      ) {
         const pat = (shift.get(i) ?? 0) | accept;
         shift.set(i, pat);
       }
@@ -93,9 +106,10 @@ export interface AsearchResult {
 /** あいまい検索を実行する函数を作る
  *
  * @param source 検索対象の文字列
+ * @param option search options
  */
-export function Asearch(source: string): AsearchResult {
-  const mask = makeMask(source);
+export function Asearch(source: string, option?: SearchOption): AsearchResult {
+  const mask = makeMask(source, option);
 
   function test(str: string, distance: 0 | 1 | 2 | 3 = 0) {
     if (str === "") return distance === source.length;


### PR DESCRIPTION
close [⬜case insensitiveの無効化optionをつける (deno-asearch)](https://scrapbox.io/takker/⬜case_insensitiveの無効化optionをつける_(deno-asearch))